### PR TITLE
feat(admin-schema-login-form): Setup schema for admin auth and initial login page template

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -10,6 +10,29 @@ datasource db {
   provider = "postgresql"
 }
 
+model Admin {
+  id Int @id @default(autoincrement())
+
+  email        String @unique
+  passwordHash String
+
+  firstName String
+  lastName  String
+
+  role Role
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+}
+
+enum Role {
+  PRESIDENT
+  VICE_PRESIDENT
+  SECRETARY
+  TREASURER
+  MEDIA
+}
+
 model Member {
   id Int @id @default(autoincrement())
 

--- a/src/app/admin/blog/page.tsx
+++ b/src/app/admin/blog/page.tsx
@@ -1,0 +1,116 @@
+import { getMockBlogItems } from "@/lib/mock/blog-posts";
+
+async function createBlogPost(formData: FormData) {
+  "use server";
+  // TODO: persist to the database via a blog repo
+  const post = {
+    title: formData.get("title"),
+    slug: formData.get("slug"),
+    description: formData.get("description"),
+    content: formData.get("content"),
+  };
+  console.log("new blog post draft", post);
+}
+
+const inputClass =
+  "block w-full rounded border border-gray-300 px-3 py-2 text-sm focus:border-black focus:outline-none";
+const labelClass = "block text-sm font-medium mb-1";
+
+export default async function AdminBlogPage() {
+  const posts = await getMockBlogItems();
+
+  return (
+    <section className="py-8">
+      <h1 className="text-3xl font-bold tracking-tight">Blog posts</h1>
+      <p className="mt-1 text-sm text-gray-600">{posts.length} published</p>
+
+      <div className="mt-6 overflow-hidden rounded-lg border border-gray-200">
+        <table className="w-full border-collapse text-sm">
+          <thead className="bg-gray-50 text-left text-xs uppercase tracking-wide text-gray-600">
+            <tr>
+              <th className="px-4 py-2 font-medium">Title</th>
+              <th className="px-4 py-2 font-medium">Slug</th>
+              <th className="px-4 py-2 font-medium">Published</th>
+            </tr>
+          </thead>
+          <tbody>
+            {posts.map((p) => (
+              <tr
+                key={p.slug}
+                className="border-t border-gray-200 hover:bg-gray-50"
+              >
+                <td className="px-4 py-2">{p.title}</td>
+                <td className="px-4 py-2 text-gray-600">{p.slug}</td>
+                <td className="px-4 py-2 text-gray-600">{p.publishedAt}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      <div className="mt-10 max-w-xl">
+        <h2 className="text-xl font-semibold">New post</h2>
+        <form action={createBlogPost} className="mt-4 space-y-4">
+          <div>
+            <label htmlFor="title" className={labelClass}>
+              Title
+            </label>
+            <input
+              id="title"
+              name="title"
+              type="text"
+              required
+              className={inputClass}
+            />
+          </div>
+
+          <div>
+            <label htmlFor="slug" className={labelClass}>
+              Slug
+            </label>
+            <input
+              id="slug"
+              name="slug"
+              type="text"
+              required
+              className={inputClass}
+            />
+          </div>
+
+          <div>
+            <label htmlFor="description" className={labelClass}>
+              Description
+            </label>
+            <input
+              id="description"
+              name="description"
+              type="text"
+              required
+              className={inputClass}
+            />
+          </div>
+
+          <div>
+            <label htmlFor="content" className={labelClass}>
+              Content
+            </label>
+            <textarea
+              id="content"
+              name="content"
+              rows={6}
+              required
+              className={inputClass}
+            />
+          </div>
+
+          <button
+            type="submit"
+            className="rounded bg-black px-4 py-2 text-sm font-medium text-white hover:bg-gray-800"
+          >
+            Publish
+          </button>
+        </form>
+      </div>
+    </section>
+  );
+}

--- a/src/app/admin/emails/page.tsx
+++ b/src/app/admin/emails/page.tsx
@@ -1,0 +1,66 @@
+import { getMockMembers } from "@/lib/mock/members";
+
+async function sendEmail(formData: FormData) {
+  "use server";
+  // TODO: Fix with real mailing list later
+  const email = {
+    subject: formData.get("subject"),
+    body: formData.get("body"),
+  };
+  console.log("mailing list send", email);
+}
+
+const inputClass =
+  "block w-full rounded border border-gray-300 px-3 py-2 text-sm focus:border-black focus:outline-none";
+const labelClass = "block text-sm font-medium mb-1";
+
+export default async function AdminEmailsPage() {
+  const members = await getMockMembers();
+
+  return (
+    <section className="py-8 max-w-xl">
+      <h1 className="text-3xl font-bold tracking-tight">Send email</h1>
+      <p className="mt-1 text-sm text-gray-600">
+        <span className="inline-block rounded-full bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-800">
+          {members.length} recipients
+        </span>{" "}
+        will receive this.
+      </p>
+
+      <form action={sendEmail} className="mt-6 space-y-4">
+        <div>
+          <label htmlFor="subject" className={labelClass}>
+            Subject
+          </label>
+          <input
+            id="subject"
+            name="subject"
+            type="text"
+            required
+            className={inputClass}
+          />
+        </div>
+
+        <div>
+          <label htmlFor="body" className={labelClass}>
+            Body
+          </label>
+          <textarea
+            id="body"
+            name="body"
+            rows={8}
+            required
+            className={inputClass}
+          />
+        </div>
+
+        <button
+          type="submit"
+          className="rounded bg-black px-4 py-2 text-sm font-medium text-white hover:bg-gray-800"
+        >
+          Send to mailing list
+        </button>
+      </form>
+    </section>
+  );
+}

--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -1,0 +1,7 @@
+export default function AdminLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return <div className="bg-white text-black">{children}</div>;
+}

--- a/src/app/admin/login/page.tsx
+++ b/src/app/admin/login/page.tsx
@@ -1,0 +1,29 @@
+async function login(formData: FormData) {
+  "use server";
+  // TODO: look up admin by email, verify password hash, set session cookie.
+  const email = formData.get("email");
+  const password = formData.get("password");
+  console.log("admin login attempt", { email, password });
+}
+
+export default function AdminLoginPage() {
+  return (
+    <>
+      <h1>Admin login</h1>
+
+      <form action={login} method="post">
+        <div>
+          <label htmlFor="email">Email</label>
+          <input id="email" name="email" type="email" required />
+        </div>
+
+        <div>
+          <label htmlFor="password">Password</label>
+          <input id="password" name="password" type="password" required />
+        </div>
+
+        <button type="submit">Log in</button>
+      </form>
+    </>
+  );
+}

--- a/src/app/admin/login/page.tsx
+++ b/src/app/admin/login/page.tsx
@@ -1,29 +1,57 @@
 async function login(formData: FormData) {
   "use server";
-  // TODO: look up admin by email, verify password hash, set session cookie.
+  // TODO: look up admin by email, verify password hash, set session cookie also all later time
   const email = formData.get("email");
   const password = formData.get("password");
   console.log("admin login attempt", { email, password });
 }
 
+const inputClass =
+  "block w-full rounded border border-gray-300 px-3 py-2 text-sm focus:border-black focus:outline-none";
+const labelClass = "block text-sm font-medium mb-1";
+
 export default function AdminLoginPage() {
   return (
-    <>
-      <h1>Admin login</h1>
+    <section className="py-12">
+      <div className="mx-auto max-w-sm rounded-lg border border-gray-200 p-6">
+        <h1 className="text-2xl font-bold tracking-tight">Admin login</h1>
+        <p className="mt-1 text-sm text-gray-600">For club executives only.</p>
 
-      <form action={login} method="post">
-        <div>
-          <label htmlFor="email">Email</label>
-          <input id="email" name="email" type="email" required />
-        </div>
+        <form action={login} className="mt-6 space-y-4">
+          <div>
+            <label htmlFor="email" className={labelClass}>
+              Email
+            </label>
+            <input
+              id="email"
+              name="email"
+              type="email"
+              required
+              className={inputClass}
+            />
+          </div>
 
-        <div>
-          <label htmlFor="password">Password</label>
-          <input id="password" name="password" type="password" required />
-        </div>
+          <div>
+            <label htmlFor="password" className={labelClass}>
+              Password
+            </label>
+            <input
+              id="password"
+              name="password"
+              type="password"
+              required
+              className={inputClass}
+            />
+          </div>
 
-        <button type="submit">Log in</button>
-      </form>
-    </>
+          <button
+            type="submit"
+            className="w-full rounded bg-black px-4 py-2 text-sm font-medium text-white hover:bg-gray-800"
+          >
+            Log in
+          </button>
+        </form>
+      </div>
+    </section>
   );
 }

--- a/src/app/admin/members/page.tsx
+++ b/src/app/admin/members/page.tsx
@@ -1,11 +1,40 @@
-export default function AdminMembers() {
-  return (
-    <div>
-      <section>
-        <h1>Admin Members</h1>
+import { getMockMembers } from "@/lib/mock/members";
 
-        <p>Placeholder Admin Members</p>
-      </section>
-    </div>
+export default async function AdminMembersPage() {
+  const members = await getMockMembers();
+
+  return (
+    <section className="py-8">
+      <h1 className="text-3xl font-bold tracking-tight">Members</h1>
+      <p className="mt-1 text-sm text-gray-600">{members.length} registered</p>
+
+      <div className="mt-6 overflow-hidden rounded-lg border border-gray-200">
+        <table className="w-full border-collapse text-sm">
+          <thead className="bg-gray-50 text-left text-xs uppercase tracking-wide text-gray-600">
+            <tr>
+              <th className="px-4 py-2 font-medium">Name</th>
+              <th className="px-4 py-2 font-medium">Email</th>
+              <th className="px-4 py-2 font-medium">Linux skill</th>
+              <th className="px-4 py-2 font-medium">Joined</th>
+            </tr>
+          </thead>
+          <tbody>
+            {members.map((m) => (
+              <tr
+                key={m.email}
+                className="border-t border-gray-200 hover:bg-gray-50"
+              >
+                <td className="px-4 py-2">
+                  {m.firstName} {m.lastName}
+                </td>
+                <td className="px-4 py-2">{m.email}</td>
+                <td className="px-4 py-2">{m.linuxSkillLevel}</td>
+                <td className="px-4 py-2">{m.joinedAt}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </section>
   );
 }

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -1,15 +1,46 @@
 import Link from "next/link";
 
+const links = [
+  {
+    href: "/admin/members",
+    label: "View members",
+    description: "Browse registered members and their details.",
+  },
+  {
+    href: "/admin/blog",
+    label: "Manage blog posts",
+    description: "See published posts and draft new ones.",
+  },
+  {
+    href: "/admin/emails",
+    label: "Send email to mailing list",
+    description: "Compose and send an email to all members.",
+  },
+];
+
 export default function AdminPage() {
   return (
-    <main className="p-6">
-      <h1 className="text-2xl font-semibold">Admin</h1>
+    <section className="py-8">
+      <h1 className="text-3xl font-bold tracking-tight">Admin</h1>
+      <p className="mt-1 text-sm text-gray-600">Tools for club executives.</p>
 
-      <div className="mt-6">
-        <Link href="/admin/members" className="underline">
-          View members
-        </Link>
-      </div>
-    </main>
+      <ul className="mt-6 grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+        {links.map((link) => (
+          <li key={link.href}>
+            <Link
+              href={link.href}
+              className="block rounded-lg border border-gray-200 p-4 transition hover:border-gray-400 hover:bg-gray-50"
+            >
+              <span className="block text-base font-semibold">
+                {link.label}
+              </span>
+              <span className="mt-1 block text-sm text-gray-600">
+                {link.description}
+              </span>
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </section>
   );
 }

--- a/src/domain/admin/types.ts
+++ b/src/domain/admin/types.ts
@@ -1,0 +1,16 @@
+export type Role =
+  | "PRESIDENT"
+  | "VICE_PRESIDENT"
+  | "SECRETARY"
+  | "TREASURER"
+  | "MEDIA";
+
+export type Admin = {
+  id: number;
+  email: string;
+  firstName: string;
+  lastName: string;
+  role: Role;
+  createdAt: Date;
+  updatedAt: Date;
+};

--- a/src/lib/mock/members.ts
+++ b/src/lib/mock/members.ts
@@ -1,0 +1,47 @@
+export type MemberRow = {
+  firstName: string;
+  lastName: string;
+  email: string;
+  linuxSkillLevel: string;
+  joinedAt: string;
+};
+
+export async function getMockMembers(): Promise<MemberRow[]> {
+  return [
+    {
+      firstName: "Ava",
+      lastName: "Nguyen",
+      email: "ava.nguyen@aucklanduni.ac.nz",
+      linuxSkillLevel: "REGULAR_USER",
+      joinedAt: "2026-03-12",
+    },
+    {
+      firstName: "Liam",
+      lastName: "Patel",
+      email: "liam.patel@aucklanduni.ac.nz",
+      linuxSkillLevel: "BEGINNER_USER",
+      joinedAt: "2026-03-15",
+    },
+    {
+      firstName: "Sophie",
+      lastName: "Chen",
+      email: "sophie.chen@aucklanduni.ac.nz",
+      linuxSkillLevel: "POWER_USER",
+      joinedAt: "2026-04-02",
+    },
+    {
+      firstName: "Marcus",
+      lastName: "Tane",
+      email: "marcus.tane@gmail.com",
+      linuxSkillLevel: "AWARE_OF_EXISTENCE",
+      joinedAt: "2026-04-18",
+    },
+    {
+      firstName: "Priya",
+      lastName: "Singh",
+      email: "priya.singh@aucklanduni.ac.nz",
+      linuxSkillLevel: "CONTRIBUTOR",
+      joinedAt: "2026-05-01",
+    },
+  ];
+}


### PR DESCRIPTION
Created a template for the admin table with required fields. Role field details can be ironed out later based on LUG feedback, but just brainstormed a few enum options here. Also set up initial structure and login page just for testing in the future.