### PR TITLE
feat(validation): add member registration form validation

### DIFF
--- a/src/domain/member/validation.ts
+++ b/src/domain/member/validation.ts
@@ -30,117 +30,45 @@ export function validateMemberRegistration(
 ):
   | { ok: true; data: MemberRegistration }
   | { ok: false; error: RegistrationFormValidationError } {
-  const requiredFields = hasRequiredFields(parsedRegistrationForm);
+  const requiredFields = validateRequiredFields(parsedRegistrationForm);
   if (requiredFields.hasRequiredFields === false) {
     return { ok: false, error: requiredFields.error };
   }
 
-  const fieldContent = validateFields(parsedRegistrationForm);
+  const fieldContent = validateFieldValues(parsedRegistrationForm);
   if (fieldContent.fieldsValid === false) {
     return { ok: false, error: fieldContent.error };
   }
 
-  return { ok: true, data: toMemberRegistrationObject(parsedRegistrationForm) };
-}
-function validateFields(
-  parsed: ParsedRegistrationFormSubmission,
-):
-  | { fieldsValid: true }
-  | { fieldsValid: false; error: RegistrationFormValidationError } {
-  if (!isValidEmail(parsed.email)) {
-    return {
-      fieldsValid: false,
-      error: {
-        message: `Email invalid: '${parsed.email}', please enter a valid email address`,
-      },
-    };
-  }
-  if (!isLinuxSkillLevel(parsed.linuxSkillLevel)) {
-    return {
-      fieldsValid: false,
-      error: {
-        message: `linuxSkillLevel property has invalid value: '${parsed.linuxSkillLevel}'`,
-      },
-    };
-  }
-  for (const option of parsed.potentialInvolvement) {
-    if (!isPotentialInvolvement(option)) {
-      return {
-        fieldsValid: false,
-        error: {
-          message: `potentialInvolvement field contains a selection with invalid value: '${option}'`,
-        },
-      };
-    }
-  }
-
-  if (
-    parsed.isConditionalReturningMember === "true" ||
-    parsed.isCurrentUoaStudent === "true"
-  ) {
-    if (!isValidUPI(parsed.upi!)) {
-      return {
-        fieldsValid: false,
-        error: {
-          message: `upi invalid: '${parsed.upi}', please enter a valid upi`,
-        },
-      };
-    }
-  }
-  if (parsed.isCurrentUoaStudent === "true") {
-    if (!isYearLevel(parsed.yearLevel)) {
-      return {
-        fieldsValid: false,
-        error: {
-          message: `yearLevel property has invalid value: ${parsed.yearLevel}`,
-        },
-      };
-    }
-  }
-
-  return { fieldsValid: true };
-}
-
-function isValidUPI(upi: string): boolean {
-  const upiRegex = /^[A-Za-z]{3,4}[0-9]{3}$/;
-  return upiRegex.test(upi);
-}
-
-function isValidEmail(email: string): boolean {
-  const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-  if (email.length > 254) {
-    return false;
-  }
-  return emailRegex.test(email);
-}
-
-function isLinuxSkillLevel(value: string | null): value is LinuxSkillLevel {
-  return (
-    value != null && validLinuxSkillLevel.includes(value as LinuxSkillLevel)
-  );
-}
-
-function isYearLevel(value: string | null): value is YearLevel {
-  return value != null && validYearLevel.includes(value as YearLevel);
-}
-
-function isPotentialInvolvement(
-  value: string | null,
-): value is PotentialInvolvement {
-  return (
-    value != null &&
-    validPotentialInvolvement.includes(value as PotentialInvolvement)
-  );
+  return { ok: true, data: toMemberRegistration(parsedRegistrationForm) };
 }
 
 //validate if required fields exist and are not null/empty string/undefined etc.
-function hasRequiredFields(
+function validateRequiredFields(
   parsed: ParsedRegistrationFormSubmission,
 ):
   | { hasRequiredFields: true }
   | { hasRequiredFields: false; error: RegistrationFormValidationError } {
   //Base fields required by all registrations
+  const baseRequiredFields = validateBaseRequiredFields(parsed);
+  if (baseRequiredFields.hasRequiredFields === false) {
+    return baseRequiredFields;
+  }
 
+  const conditionalRequiredFields =
+    validateRegistrationPathRequiredFields(parsed);
+  if (conditionalRequiredFields.hasRequiredFields === false) {
+    return conditionalRequiredFields;
+  }
+
+  return { hasRequiredFields: true };
+}
+
+function validateBaseRequiredFields(
+  parsed: ParsedRegistrationFormSubmission,
+):
+  | { hasRequiredFields: true }
+  | { hasRequiredFields: false; error: RegistrationFormValidationError } {
   const requiredFields: string[] = [
     "firstName",
     "lastName",
@@ -178,7 +106,14 @@ function hasRequiredFields(
       },
     };
   }
+  return { hasRequiredFields: true };
+}
 
+function validateRegistrationPathRequiredFields(
+  parsed: ParsedRegistrationFormSubmission,
+):
+  | { hasRequiredFields: true }
+  | { hasRequiredFields: false; error: RegistrationFormValidationError } {
   //check if the value of isConditionalReturningMember and isCurrentUoaStudent is valid.
   //It is a validity check(thus should be in validateFields function) but is required for the following checks so is moved here.
   if (
@@ -278,50 +213,94 @@ function hasRequiredFields(
   return { hasRequiredFields: true };
 }
 
-function toMemberRegistrationObject(
+function validateFieldValues(
+  parsed: ParsedRegistrationFormSubmission,
+):
+  | { fieldsValid: true }
+  | { fieldsValid: false; error: RegistrationFormValidationError } {
+  if (!isValidEmail(parsed.email)) {
+    return {
+      fieldsValid: false,
+      error: {
+        message: `Email invalid: '${parsed.email}', please enter a valid email address`,
+      },
+    };
+  }
+  if (!isLinuxSkillLevel(parsed.linuxSkillLevel)) {
+    return {
+      fieldsValid: false,
+      error: {
+        message: `linuxSkillLevel property has invalid value: '${parsed.linuxSkillLevel}'`,
+      },
+    };
+  }
+  for (const option of parsed.potentialInvolvement) {
+    if (!isPotentialInvolvement(option)) {
+      return {
+        fieldsValid: false,
+        error: {
+          message: `potentialInvolvement field contains a selection with invalid value: '${option}'`,
+        },
+      };
+    }
+  }
+
+  if (
+    parsed.isConditionalReturningMember === "true" ||
+    parsed.isCurrentUoaStudent === "true"
+  ) {
+    if (!isValidUPI(parsed.upi!)) {
+      return {
+        fieldsValid: false,
+        error: {
+          message: `upi invalid: '${parsed.upi}', please enter a valid upi`,
+        },
+      };
+    }
+  }
+  if (parsed.isCurrentUoaStudent === "true") {
+    if (!isYearLevel(parsed.yearLevel)) {
+      return {
+        fieldsValid: false,
+        error: {
+          message: `yearLevel property has invalid value: ${parsed.yearLevel}`,
+        },
+      };
+    }
+  }
+
+  return { fieldsValid: true };
+}
+
+function toMemberRegistration(
   parsedForm: ParsedRegistrationFormSubmission,
 ): MemberRegistration {
   if (parsedForm.isConditionalReturningMember === "true") {
     return toConditionalReturningMember(parsedForm);
   } else if (parsedForm.isCurrentUoaStudent === "true") {
-    return toCurrentUoaStudent(parsedForm);
+    return toCurrentUoaStudentMember(parsedForm);
   } else {
     return toNonCurrentUoaStudentMember(parsedForm);
   }
-}
-
-function toNonCurrentUoaStudentMember(
-  parsed: ParsedRegistrationFormSubmission,
-): NonCurrentUoaStudentMember {
-  const nonUoaMember: NonCurrentUoaStudentMember = {
-    ...toBaseMember(parsed),
-    isConditionalReturningMember: false,
-    isCurrentUoaStudent: false,
-    primaryAffiliation: parsed.primaryAffiliation!,
-    ...(parsed.nonUoaExcerpt != null
-      ? { nonUoaExcerpt: parsed.nonUoaExcerpt }
-      : {}),
-    ...(parsed.nonUoaPitch != null ? { nonUoaPitch: parsed.nonUoaPitch } : {}),
-  };
-  return nonUoaMember;
 }
 
 function toConditionalReturningMember(
   parsed: ParsedRegistrationFormSubmission,
 ): ConditionalReturningMember {
   const returningMember: ConditionalReturningMember = {
-    ...toBaseMember(parsed),
+    ...toBaseMemberRegistration(parsed),
     isConditionalReturningMember: true,
     upi: parsed.upi!,
     studentId: parsed.studentId!,
   };
   return returningMember;
 }
-function toCurrentUoaStudent(
+
+function toCurrentUoaStudentMember(
   parsed: ParsedRegistrationFormSubmission,
 ): CurrentUoaStudentMember {
   const uoaMember: CurrentUoaStudentMember = {
-    ...toBaseMember(parsed),
+    ...toBaseMemberRegistration(parsed),
     isConditionalReturningMember: false,
     isCurrentUoaStudent: true,
 
@@ -333,7 +312,23 @@ function toCurrentUoaStudent(
   };
   return uoaMember;
 }
-function toBaseMember(
+function toNonCurrentUoaStudentMember(
+  parsed: ParsedRegistrationFormSubmission,
+): NonCurrentUoaStudentMember {
+  const nonUoaMember: NonCurrentUoaStudentMember = {
+    ...toBaseMemberRegistration(parsed),
+    isConditionalReturningMember: false,
+    isCurrentUoaStudent: false,
+    primaryAffiliation: parsed.primaryAffiliation!,
+    ...(parsed.nonUoaExcerpt != null
+      ? { nonUoaExcerpt: parsed.nonUoaExcerpt }
+      : {}),
+    ...(parsed.nonUoaPitch != null ? { nonUoaPitch: parsed.nonUoaPitch } : {}),
+  };
+  return nonUoaMember;
+}
+
+function toBaseMemberRegistration(
   parsed: ParsedRegistrationFormSubmission,
 ): BaseMemberRegistration {
   const baseRegistration: BaseMemberRegistration = {
@@ -349,4 +344,36 @@ function toBaseMember(
       : {}),
   };
   return baseRegistration;
+}
+
+function isValidUPI(upi: string): boolean {
+  const upiRegex = /^[A-Za-z]{3,4}[0-9]{3}$/;
+  return upiRegex.test(upi);
+}
+
+function isValidEmail(email: string): boolean {
+  const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+  if (email.length > 254) {
+    return false;
+  }
+  return emailRegex.test(email);
+}
+
+function isLinuxSkillLevel(value: string | null): value is LinuxSkillLevel {
+  return (
+    value != null && validLinuxSkillLevel.includes(value as LinuxSkillLevel)
+  );
+}
+
+function isYearLevel(value: string | null): value is YearLevel {
+  return value != null && validYearLevel.includes(value as YearLevel);
+}
+
+function isPotentialInvolvement(
+  value: string | null,
+): value is PotentialInvolvement {
+  return (
+    value != null &&
+    validPotentialInvolvement.includes(value as PotentialInvolvement)
+  );
 }

--- a/src/domain/member/validation.ts
+++ b/src/domain/member/validation.ts
@@ -1,0 +1,191 @@
+import { PotentialInvolvement } from "@/generated/prisma/enums";
+
+type RegistrationFormValidationError = {
+  message: string;
+};
+
+export function validateMemberRegistration(
+  parsedRegistrationForm: ParsedRegistrationFormSubmission,
+):
+  | { ok: true; data: MemberRegistration }
+  | { ok: false; error: RegistrationFormValidationError } {
+  const requiredFields = hasRequiredFields(parsedRegistrationForm);
+  if (requiredFields.hasRequiredFields == false) {
+    return { ok: false, error: requiredFields.error };
+  }
+
+  if (!isValidEmail(parsedRegistrationForm.email)) {
+    return {
+      ok: false,
+      error: { message: "Email invalid: please enter a valid email address" },
+    };
+  }
+
+  return { ok: true, data: toMemberRegistrationObject(parsedRegistrationForm) };
+}
+
+function isValidEmail(email: string): boolean {
+  const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+  if (email.length > 254) {
+    return false;
+  }
+  return emailRegex.test(email);
+}
+
+//validate if required fields exist and are not null/empty string/undefined etc.
+function hasRequiredFields(
+  parsed: ParsedRegistrationFormSubmission,
+):
+  | { hasRequiredFields: true }
+  | { hasRequiredFields: false; error: RegistrationFormValidationError } {
+  //Base fields required by all registrations
+  const requiredFields: string[] = [
+    "firstName",
+    "lastName",
+    "email",
+    "linuxSkillLevel",
+    "potentialInvolvement",
+  ];
+  const errorDisplayNames: string[] = [
+    "first name",
+    "last name",
+    "email",
+    "linux skill level",
+    "potential involvement",
+  ];
+  for (const field of requiredFields) {
+    if (!(field in parsed) || !parsed[field]) {
+      const displayName = errorDisplayNames[requiredFields.indexOf(field)];
+      return {
+        valid: false,
+        error: { message: "${displayName} field is required" },
+      };
+    }
+  }
+  // Further check for fields that are only required if specific conditions are met
+  if (parsed.isEligibleReturningUoaStudent == "true") {
+    if (!parsed.upi) {
+      return {
+        hasRequiredFields: false,
+        error: { message: "upi field is required for Uoa students" },
+      };
+    }
+    if (!parsed.studentId) {
+      return {
+        hasRequiredFields: false,
+        error: { message: "Student ID field is required for Uoa students" },
+      };
+    }
+  } else if (parsed.isCurrentUoaStudent == "true") {
+    const requiredFieldsUoa = [
+      "upi",
+      "studentId",
+      "faculty",
+      "programme",
+      "yearLevel",
+    ];
+    const errorDisplayNamesUoa = [
+      "upi",
+      "Student ID",
+      "Faculty",
+      "Programme",
+      "Year level",
+    ];
+    for (const field of requiredFieldsUoa) {
+      if (!(field in parsed) || !parsed[field]) {
+        const displayName =
+          errorDisplayNamesUoa[requiredFieldsUoa.indexOf(field)];
+        return {
+          hasRequiredFields: false,
+          error: {
+            message: "${displayName} field is required for Uoa students",
+          },
+        };
+      }
+    }
+  } else if (parsed.isCurrentUoaStudent == "false") {
+    if (!parsed.primaryAffiliation) {
+      return {
+        hasRequiredFields: false,
+        error: {
+          message:
+            "Primary Affiliation field is required for non-Uoa candidates",
+        },
+      };
+    }
+  }
+  return { hasRequiredFields: true };
+}
+
+function toMemberRegistrationObject(
+  parsedForm: ParsedRegistrationFormSubmission,
+): MemberRegistration {
+  if (parsedForm.isEligibleReturningUoaStudent == "true") {
+    return toConditionalReturningMember(parsedForm);
+  } else if (parsedForm.isCurrentUoaStudent == "true") {
+    return toCurrentUoaStudent(parsedForm);
+  } else if (parsedForm.isCurrentUoaStudent == "false") {
+    return toNonCurrentUoaStudentMember(parsedForm);
+  }
+}
+
+function toNonCurrentUoaStudentMember(
+  parsed: ParsedRegistrationFormSubmission,
+): NonCurrentUoaStudentMember {
+  const nonUoaMember: NonCurrentUoaStudentMember = {
+    ...toBaseMember(parsed),
+    isEligibleReturningUoaStudent: false,
+    isCurrentUoaStudent: false,
+    primaryAffiliation: parsed.primaryAffiliation,
+    ...(parsed.nonUoaExcerpt != null
+      ? { nonUoaExcerpt: parsed.nonUoaExcerpt }
+      : {}),
+    ...(parsed.nonUoaPitch != null ? { nonUoaPitch: parsed.nonUoaPitch } : {}),
+  };
+  return nonUoaMember;
+}
+
+function toConditionalReturningMember(
+  parsed: ParsedRegistrationFormSubmission,
+): ConditionalReturningMember {
+  const returningMember: ConditionalReturningMember = {
+    ...toBaseMember(parsed),
+    isEligibleReturningUoaStudent: true,
+    upi: parsed.upi,
+    studentId: parsed.studentId,
+  };
+  return returningMember;
+}
+function toCurrentUoaStudent(
+  parsed: ParsedRegistrationFormSubmission,
+): CurrentUoaStudentMember {
+  const uoaMember: CurrentUoaStudentMember = {
+    ...toBaseMember(parsed),
+    isEligibleReturningUoaStudent: false,
+    isCurrentUoaStudent: true,
+
+    upi: parsed.upi,
+    studentId: parsed.studentId,
+    faculty: parsed.faculty,
+    programme: parsed.programme,
+    yearLevel: parsed.yearLevel,
+  };
+  return uoaMember;
+}
+function toBaseMember(
+  parsed: ParsedRegistrationFormSubmission,
+): BaseMemberRegistration {
+  const baseRegistration: BaseMemberRegistration = {
+    firstName: parsed.firstName,
+    lastName: parsed.lastName,
+    email: parsed.email,
+
+    linuxSkillLevel: parsed.linuxSkillLevel,
+    potentialInvolvement: parsed.potentialInvolvement,
+    //only create dc username property if property exists in provided info
+    ...(parsed.discordUsername != null
+      ? { discordUsername: parsed.discordUsername }
+      : {}),
+  };
+  return baseRegistration;
+}

--- a/src/domain/member/validation.ts
+++ b/src/domain/member/validation.ts
@@ -1,5 +1,3 @@
-import { PotentialInvolvement } from "@/generated/prisma/enums";
-
 const validYearLevel = [
   "FIRST_YEAR",
   "SECOND_YEAR",
@@ -33,12 +31,12 @@ export function validateMemberRegistration(
   | { ok: true; data: MemberRegistration }
   | { ok: false; error: RegistrationFormValidationError } {
   const requiredFields = hasRequiredFields(parsedRegistrationForm);
-  if (requiredFields.hasRequiredFields == false) {
+  if (requiredFields.hasRequiredFields === false) {
     return { ok: false, error: requiredFields.error };
   }
 
   const fieldContent = validateFields(parsedRegistrationForm);
-  if (fieldContent.fieldsValid == false) {
+  if (fieldContent.fieldsValid === false) {
     return { ok: false, error: fieldContent.error };
   }
 
@@ -57,9 +55,7 @@ function validateFields(
       },
     };
   }
-  if (
-    !validLinuxSkillLevel.includes(parsed.linuxSkillLevel as LinuxSkillLevel)
-  ) {
+  if (!isLinuxSkillLevel(parsed.linuxSkillLevel)) {
     return {
       fieldsValid: false,
       error: {
@@ -68,7 +64,7 @@ function validateFields(
     };
   }
   for (const option of parsed.potentialInvolvement) {
-    if (!validPotentialInvolvement.includes(option)) {
+    if (!isPotentialInvolvement(option)) {
       return {
         fieldsValid: false,
         error: {
@@ -79,22 +75,24 @@ function validateFields(
   }
 
   if (
-    parsed.isCurrentUoaStudent == "true" ||
-    parsed.isEligibleReturningUoaStudent == "true"
+    parsed.isConditionalReturningMember === "true" ||
+    parsed.isCurrentUoaStudent === "true"
   ) {
-    if (!validYearLevel.includes(parsed.yearLevel as YearLevel)) {
-      return {
-        fieldsValid: false,
-        error: {
-          message: `yearLevel property has invalid value: ${parsed.yearLevel}`,
-        },
-      };
-    }
     if (!isValidUPI(parsed.upi!)) {
       return {
         fieldsValid: false,
         error: {
           message: `upi invalid: '${parsed.upi}', please enter a valid upi`,
+        },
+      };
+    }
+  }
+  if (parsed.isCurrentUoaStudent === "true") {
+    if (!isYearLevel(parsed.yearLevel)) {
+      return {
+        fieldsValid: false,
+        error: {
+          message: `yearLevel property has invalid value: ${parsed.yearLevel}`,
         },
       };
     }
@@ -116,6 +114,25 @@ function isValidEmail(email: string): boolean {
   return emailRegex.test(email);
 }
 
+function isLinuxSkillLevel(value: string | null): value is LinuxSkillLevel {
+  return (
+    value != null && validLinuxSkillLevel.includes(value as LinuxSkillLevel)
+  );
+}
+
+function isYearLevel(value: string | null): value is YearLevel {
+  return value != null && validYearLevel.includes(value as YearLevel);
+}
+
+function isPotentialInvolvement(
+  value: string | null,
+): value is PotentialInvolvement {
+  return (
+    value != null &&
+    validPotentialInvolvement.includes(value as PotentialInvolvement)
+  );
+}
+
 //validate if required fields exist and are not null/empty string/undefined etc.
 function hasRequiredFields(
   parsed: ParsedRegistrationFormSubmission,
@@ -130,8 +147,7 @@ function hasRequiredFields(
     "email",
     "linuxSkillLevel",
     "potentialInvolvement",
-    "isEligibleReturningUoaStudent",
-    "isCurrentUoaStudent",
+    "isConditionalReturningMember",
   ];
   const errorDisplayNames: string[] = [
     "First name",
@@ -139,8 +155,7 @@ function hasRequiredFields(
     "Email",
     "Linux skill level",
     "Potential involvement",
-    "Is eligible returning Uoa student",
-    "Is current Uoa student",
+    "Is Conditional Returning Member",
   ];
   for (const field of requiredFields) {
     if (!(field in parsed) || !parsed[field as keyof typeof parsed]) {
@@ -164,30 +179,42 @@ function hasRequiredFields(
     };
   }
 
-  //check if the value of isEligibleReturningUoaStudent and isCurrentUoaStudent is valid.
+  //check if the value of isConditionalReturningMember and isCurrentUoaStudent is valid.
   //It is a validity check(thus should be in validateFields function) but is required for the following checks so is moved here.
   if (
-    !["true", "false"].includes(parsed.isEligibleReturningUoaStudent as string)
+    !["true", "false"].includes(parsed.isConditionalReturningMember as string)
   ) {
     return {
       hasRequiredFields: false,
       error: {
-        message: `isEligibleReturningUoaStudent field has value: '${parsed.isEligibleReturningUoaStudent}' must either have value 'true' or 'false'`,
-      },
-    };
-  }
-  if (!["true", "false"].includes(parsed.isCurrentUoaStudent as string)) {
-    return {
-      hasRequiredFields: false,
-      error: {
-        message:
-          "isCurrentUoaStudent field must either have value 'true' or 'false'",
+        message: `isConditionalReturningMember field has value: '${parsed.isConditionalReturningMember}', must either have value 'true' or 'false'`,
       },
     };
   }
 
+  // If Conditional Returning Member is false, then isCurrentUoaStudent becomes a required field
+  if (parsed.isConditionalReturningMember === "false") {
+    if (!("isCurrentUoaStudent" in parsed) || !parsed.isCurrentUoaStudent) {
+      return {
+        hasRequiredFields: false,
+        error: {
+          message:
+            "'isCurrentUoaStudent' field is required if not a Conditional Returning Member",
+        },
+      };
+    }
+    if (!["true", "false"].includes(parsed.isCurrentUoaStudent as string)) {
+      return {
+        hasRequiredFields: false,
+        error: {
+          message: `isCurrentUoaStudent field has value: '${parsed.isCurrentUoaStudent}', must either have value 'true' or 'false'`,
+        },
+      };
+    }
+  }
+
   // Further check for fields that are only required if specific conditions are met
-  if (parsed.isEligibleReturningUoaStudent == "true") {
+  if (parsed.isConditionalReturningMember === "true") {
     if (!("upi" in parsed) || !parsed.upi) {
       return {
         hasRequiredFields: false,
@@ -200,7 +227,7 @@ function hasRequiredFields(
         error: { message: "Student ID field is required for Uoa students" },
       };
     }
-  } else if (parsed.isCurrentUoaStudent == "true") {
+  } else if (parsed.isCurrentUoaStudent === "true") {
     const requiredFieldsUoa = [
       "upi",
       "studentId",
@@ -227,7 +254,17 @@ function hasRequiredFields(
         };
       }
     }
-  } else if (parsed.isCurrentUoaStudent == "false") {
+
+    //Extra check for if faculty is empty, at this point existence of faculty field is verified.
+    if (parsed.faculty!.length === 0) {
+      return {
+        hasRequiredFields: false,
+        error: {
+          message: "'faculty' field must not be an empty array",
+        },
+      };
+    }
+  } else if (parsed.isCurrentUoaStudent === "false") {
     if (!("primaryAffiliation" in parsed) || !parsed.primaryAffiliation) {
       return {
         hasRequiredFields: false,
@@ -244,9 +281,9 @@ function hasRequiredFields(
 function toMemberRegistrationObject(
   parsedForm: ParsedRegistrationFormSubmission,
 ): MemberRegistration {
-  if (parsedForm.isEligibleReturningUoaStudent == "true") {
+  if (parsedForm.isConditionalReturningMember === "true") {
     return toConditionalReturningMember(parsedForm);
-  } else if (parsedForm.isCurrentUoaStudent == "true") {
+  } else if (parsedForm.isCurrentUoaStudent === "true") {
     return toCurrentUoaStudent(parsedForm);
   } else {
     return toNonCurrentUoaStudentMember(parsedForm);
@@ -258,7 +295,7 @@ function toNonCurrentUoaStudentMember(
 ): NonCurrentUoaStudentMember {
   const nonUoaMember: NonCurrentUoaStudentMember = {
     ...toBaseMember(parsed),
-    isEligibleReturningUoaStudent: false,
+    isConditionalReturningMember: false,
     isCurrentUoaStudent: false,
     primaryAffiliation: parsed.primaryAffiliation!,
     ...(parsed.nonUoaExcerpt != null
@@ -274,7 +311,7 @@ function toConditionalReturningMember(
 ): ConditionalReturningMember {
   const returningMember: ConditionalReturningMember = {
     ...toBaseMember(parsed),
-    isEligibleReturningUoaStudent: true,
+    isConditionalReturningMember: true,
     upi: parsed.upi!,
     studentId: parsed.studentId!,
   };
@@ -285,7 +322,7 @@ function toCurrentUoaStudent(
 ): CurrentUoaStudentMember {
   const uoaMember: CurrentUoaStudentMember = {
     ...toBaseMember(parsed),
-    isEligibleReturningUoaStudent: false,
+    isConditionalReturningMember: false,
     isCurrentUoaStudent: true,
 
     upi: parsed.upi!,

--- a/src/domain/member/validation.ts
+++ b/src/domain/member/validation.ts
@@ -14,14 +14,26 @@ export function validateMemberRegistration(
     return { ok: false, error: requiredFields.error };
   }
 
-  if (!isValidEmail(parsedRegistrationForm.email)) {
-    return {
-      ok: false,
-      error: { message: "Email invalid: please enter a valid email address" },
-    };
+  const fieldContent = validateFields(parsedRegistrationForm);
+  if (fieldContent.fieldsValid == false) {
+    return { ok: false, error: fieldContent.error };
   }
 
   return { ok: true, data: toMemberRegistrationObject(parsedRegistrationForm) };
+}
+
+function validateFields(
+  parsed: ParsedRegistrationFormSubmission,
+):
+  | { fieldsValid: true }
+  | { fieldsValid: false; error: RegistrationFormValidationError } {
+  if (!isValidEmail(parsed.email)) {
+    return {
+      fieldsValid: false,
+      error: { message: "Email invalid: please enter a valid email address" },
+    };
+  }
+  return { fieldsValid: true };
 }
 
 function isValidEmail(email: string): boolean {
@@ -47,17 +59,17 @@ function hasRequiredFields(
     "potentialInvolvement",
   ];
   const errorDisplayNames: string[] = [
-    "first name",
-    "last name",
-    "email",
-    "linux skill level",
-    "potential involvement",
+    "First name",
+    "Last name",
+    "Email",
+    "Linux skill level",
+    "Potential involvement",
   ];
   for (const field of requiredFields) {
     if (!(field in parsed) || !parsed[field]) {
       const displayName = errorDisplayNames[requiredFields.indexOf(field)];
       return {
-        valid: false,
+        hasRequiredFields: false,
         error: { message: "${displayName} field is required" },
       };
     }

--- a/src/domain/member/validation.ts
+++ b/src/domain/member/validation.ts
@@ -1,5 +1,28 @@
 import { PotentialInvolvement } from "@/generated/prisma/enums";
 
+const validYearLevel = [
+  "FIRST_YEAR",
+  "SECOND_YEAR",
+  "THIRD_YEAR",
+  "FOURTH_YEAR",
+  "FIFTH_YEAR_OR_LATER",
+  "GRADUATED_WITHIN_2_YEARS",
+] as const;
+const validPotentialInvolvement = [
+  "ATTENDING",
+  "SPEAKING",
+  "EXECUTIVE",
+  "PROJECTS",
+] as const;
+const validLinuxSkillLevel = [
+  "NOTHING",
+  "AWARE_OF_EXISTENCE",
+  "BEGINNER_USER",
+  "REGULAR_USER",
+  "POWER_USER",
+  "CONTRIBUTOR",
+] as const;
+
 type RegistrationFormValidationError = {
   message: string;
 };
@@ -21,7 +44,6 @@ export function validateMemberRegistration(
 
   return { ok: true, data: toMemberRegistrationObject(parsedRegistrationForm) };
 }
-
 function validateFields(
   parsed: ParsedRegistrationFormSubmission,
 ):
@@ -30,10 +52,60 @@ function validateFields(
   if (!isValidEmail(parsed.email)) {
     return {
       fieldsValid: false,
-      error: { message: "Email invalid: please enter a valid email address" },
+      error: {
+        message: `Email invalid: '${parsed.email}', please enter a valid email address`,
+      },
     };
   }
+  if (
+    !validLinuxSkillLevel.includes(parsed.linuxSkillLevel as LinuxSkillLevel)
+  ) {
+    return {
+      fieldsValid: false,
+      error: {
+        message: `linuxSkillLevel property has invalid value: '${parsed.linuxSkillLevel}'`,
+      },
+    };
+  }
+  for (const option of parsed.potentialInvolvement) {
+    if (!validPotentialInvolvement.includes(option)) {
+      return {
+        fieldsValid: false,
+        error: {
+          message: `potentialInvolvement field contains a selection with invalid value: '${option}'`,
+        },
+      };
+    }
+  }
+
+  if (
+    parsed.isCurrentUoaStudent == "true" ||
+    parsed.isEligibleReturningUoaStudent == "true"
+  ) {
+    if (!validYearLevel.includes(parsed.yearLevel as YearLevel)) {
+      return {
+        fieldsValid: false,
+        error: {
+          message: `yearLevel property has invalid value: ${parsed.yearLevel}`,
+        },
+      };
+    }
+    if (!isValidUPI(parsed.upi!)) {
+      return {
+        fieldsValid: false,
+        error: {
+          message: `upi invalid: '${parsed.upi}', please enter a valid upi`,
+        },
+      };
+    }
+  }
+
   return { fieldsValid: true };
+}
+
+function isValidUPI(upi: string): boolean {
+  const upiRegex = /^[A-Za-z]{3,4}[0-9]{3}$/;
+  return upiRegex.test(upi);
 }
 
 function isValidEmail(email: string): boolean {
@@ -51,12 +123,15 @@ function hasRequiredFields(
   | { hasRequiredFields: true }
   | { hasRequiredFields: false; error: RegistrationFormValidationError } {
   //Base fields required by all registrations
+
   const requiredFields: string[] = [
     "firstName",
     "lastName",
     "email",
     "linuxSkillLevel",
     "potentialInvolvement",
+    "isEligibleReturningUoaStudent",
+    "isCurrentUoaStudent",
   ];
   const errorDisplayNames: string[] = [
     "First name",
@@ -64,25 +139,62 @@ function hasRequiredFields(
     "Email",
     "Linux skill level",
     "Potential involvement",
+    "Is eligible returning Uoa student",
+    "Is current Uoa student",
   ];
   for (const field of requiredFields) {
-    if (!(field in parsed) || !parsed[field]) {
+    if (!(field in parsed) || !parsed[field as keyof typeof parsed]) {
       const displayName = errorDisplayNames[requiredFields.indexOf(field)];
       return {
         hasRequiredFields: false,
-        error: { message: "${displayName} field is required" },
+        error: {
+          message: `'${displayName}' field is required, and must not be null or empty`,
+        },
       };
     }
   }
+
+  if (parsed.potentialInvolvement.length === 0) {
+    return {
+      hasRequiredFields: false,
+      error: {
+        message:
+          "At least one option for Potential Involvement must be selected",
+      },
+    };
+  }
+
+  //check if the value of isEligibleReturningUoaStudent and isCurrentUoaStudent is valid.
+  //It is a validity check(thus should be in validateFields function) but is required for the following checks so is moved here.
+  if (
+    !["true", "false"].includes(parsed.isEligibleReturningUoaStudent as string)
+  ) {
+    return {
+      hasRequiredFields: false,
+      error: {
+        message: `isEligibleReturningUoaStudent field has value: '${parsed.isEligibleReturningUoaStudent}' must either have value 'true' or 'false'`,
+      },
+    };
+  }
+  if (!["true", "false"].includes(parsed.isCurrentUoaStudent as string)) {
+    return {
+      hasRequiredFields: false,
+      error: {
+        message:
+          "isCurrentUoaStudent field must either have value 'true' or 'false'",
+      },
+    };
+  }
+
   // Further check for fields that are only required if specific conditions are met
   if (parsed.isEligibleReturningUoaStudent == "true") {
-    if (!parsed.upi) {
+    if (!("upi" in parsed) || !parsed.upi) {
       return {
         hasRequiredFields: false,
         error: { message: "upi field is required for Uoa students" },
       };
     }
-    if (!parsed.studentId) {
+    if (!("studentId" in parsed) || !parsed.studentId) {
       return {
         hasRequiredFields: false,
         error: { message: "Student ID field is required for Uoa students" },
@@ -104,24 +216,24 @@ function hasRequiredFields(
       "Year level",
     ];
     for (const field of requiredFieldsUoa) {
-      if (!(field in parsed) || !parsed[field]) {
+      if (!(field in parsed) || !parsed[field as keyof typeof parsed]) {
         const displayName =
           errorDisplayNamesUoa[requiredFieldsUoa.indexOf(field)];
         return {
           hasRequiredFields: false,
           error: {
-            message: "${displayName} field is required for Uoa students",
+            message: `'${displayName}' field is required for Uoa students, and must not be null or empty`,
           },
         };
       }
     }
   } else if (parsed.isCurrentUoaStudent == "false") {
-    if (!parsed.primaryAffiliation) {
+    if (!("primaryAffiliation" in parsed) || !parsed.primaryAffiliation) {
       return {
         hasRequiredFields: false,
         error: {
           message:
-            "Primary Affiliation field is required for non-Uoa candidates",
+            "'Primary Affiliation' field is required for non-Uoa candidates, and must not be null or empty",
         },
       };
     }
@@ -136,7 +248,7 @@ function toMemberRegistrationObject(
     return toConditionalReturningMember(parsedForm);
   } else if (parsedForm.isCurrentUoaStudent == "true") {
     return toCurrentUoaStudent(parsedForm);
-  } else if (parsedForm.isCurrentUoaStudent == "false") {
+  } else {
     return toNonCurrentUoaStudentMember(parsedForm);
   }
 }
@@ -148,7 +260,7 @@ function toNonCurrentUoaStudentMember(
     ...toBaseMember(parsed),
     isEligibleReturningUoaStudent: false,
     isCurrentUoaStudent: false,
-    primaryAffiliation: parsed.primaryAffiliation,
+    primaryAffiliation: parsed.primaryAffiliation!,
     ...(parsed.nonUoaExcerpt != null
       ? { nonUoaExcerpt: parsed.nonUoaExcerpt }
       : {}),
@@ -163,8 +275,8 @@ function toConditionalReturningMember(
   const returningMember: ConditionalReturningMember = {
     ...toBaseMember(parsed),
     isEligibleReturningUoaStudent: true,
-    upi: parsed.upi,
-    studentId: parsed.studentId,
+    upi: parsed.upi!,
+    studentId: parsed.studentId!,
   };
   return returningMember;
 }
@@ -176,11 +288,11 @@ function toCurrentUoaStudent(
     isEligibleReturningUoaStudent: false,
     isCurrentUoaStudent: true,
 
-    upi: parsed.upi,
-    studentId: parsed.studentId,
-    faculty: parsed.faculty,
-    programme: parsed.programme,
-    yearLevel: parsed.yearLevel,
+    upi: parsed.upi!,
+    studentId: parsed.studentId!,
+    faculty: parsed.faculty!,
+    programme: parsed.programme!,
+    yearLevel: parsed.yearLevel!,
   };
   return uoaMember;
 }


### PR DESCRIPTION
Wrote functionality for validating parsed registration form data.
Edited only src/domain/member/validation.ts
Exported function validateMemberRegistration which takes a ParsedRegistrationFormSubmission and returns an object with properties ok: true/false, along with either a data object/error object respectively.
Function checks if required fields are present based on conditions, and checks field validity as described in issue #43 
"data" object conforms to shape of one of ConditionalReturningMember, CurrentUoaStudentMember, or NonCurrentUoaStudentMember
"error" object currently has only "message" property, which will contain a brief description of where validation failed.
